### PR TITLE
feat: fail to start on insecure config file (perms wider than 0600)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can either pass them as the above environment variables (good for CI and Dev
 # download the example config file at the default path, then customize to your needs
 mkdir ~/.config/vault-conductor
 curl -sSL https://github.com/pirafrank/vault-conductor/raw/refs/heads/main/config.yaml.example > ~/.config/vault-conductor/config.yaml
-chmod 0660 ~/.config/vault-conductor/config.yaml
+chmod 0600 ~/.config/vault-conductor/config.yaml
 ```
 
 ## Usage

--- a/docs/CONFIG_LOAD.md
+++ b/docs/CONFIG_LOAD.md
@@ -14,9 +14,9 @@ flowchart TD
     UseProvided --> FileExists{File exists?}
     UseDefault --> FileExists
 
-    FileExists -->|Yes| CheckPermissions{Permissions<br/>exactly 0600?}
+    FileExists -->|Yes| CheckPermissions{Owner-only permissions?}
     CheckPermissions -->|Yes| ReadFile[Read config file]
-    CheckPermissions -->|No| Error3[Error: Config file permissions must be 0600]
+    CheckPermissions -->|No| Error3[Error: Config file must not grant group or other permissions]
     FileExists -->|No| CheckEnv{Environment<br/>variables set?}
 
     ReadFile --> ParseYAML[Parse YAML]

--- a/docs/CONFIG_LOAD.md
+++ b/docs/CONFIG_LOAD.md
@@ -14,8 +14,9 @@ flowchart TD
     UseProvided --> FileExists{File exists?}
     UseDefault --> FileExists
 
-    FileExists -->|Yes| CheckPermissions[Check permissions<br/>warn unless 0600]
-    CheckPermissions --> ReadFile[Read config file]
+    FileExists -->|Yes| CheckPermissions{Permissions<br/>exactly 0600?}
+    CheckPermissions -->|Yes| ReadFile[Read config file]
+    CheckPermissions -->|No| Error3[Error: Config file permissions must be 0600]
     FileExists -->|No| CheckEnv{Environment<br/>variables set?}
 
     ReadFile --> ParseYAML[Parse YAML]

--- a/docs/CONFIG_LOAD.md
+++ b/docs/CONFIG_LOAD.md
@@ -14,9 +14,10 @@ flowchart TD
     UseProvided --> FileExists{File exists?}
     UseDefault --> FileExists
 
-    FileExists -->|Yes| CheckPermissions{Owner-only permissions?}
+    FileExists -->|Yes, Unix| CheckPermissions{Owner-only permissions?}
     CheckPermissions -->|Yes| ReadFile[Read config file]
     CheckPermissions -->|No| Error3[Error: Config file must not grant group or other permissions]
+    FileExists -->|Yes, non-Unix| ReadFile
     FileExists -->|No| CheckEnv{Environment<br/>variables set?}
 
     ReadFile --> ParseYAML[Parse YAML]

--- a/docs/CONFIG_LOAD.md
+++ b/docs/CONFIG_LOAD.md
@@ -14,7 +14,8 @@ flowchart TD
     UseProvided --> FileExists{File exists?}
     UseDefault --> FileExists
 
-    FileExists -->|Yes| ReadFile[Read config file]
+    FileExists -->|Yes| CheckPermissions[Check permissions<br/>warn unless 0600]
+    CheckPermissions --> ReadFile[Read config file]
     FileExists -->|No| CheckEnv{Environment<br/>variables set?}
 
     ReadFile --> ParseYAML[Parse YAML]

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,12 +126,13 @@ pub fn inspect_config_permissions(config_path: &PathBuf) -> Result<Option<u32>> 
     let mode = metadata.permissions().mode() & 0o7777;
 
     if mode != 0o600 {
-        log::warn!(
-            "Config file {} has permissions {:04o}; recommended permissions are 0600",
+        let msg = format!(
+            "Config file {} has permissions {:04o}; required permissions are 0600",
             config_path.display(),
             mode
         );
-        return Ok(Some(mode));
+        log::error!("{}", msg);
+        bail!("{}", msg);
     }
 
     Ok(None)

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,8 @@ impl Config {
 
         // Try to load from config file first
         if config_path.exists() {
+            let _ = inspect_config_permissions(&config_path)?;
+
             let config_content = std::fs::read_to_string(&config_path).with_context(|| {
                 format!(
                     "Failed to read content of config file: {}",
@@ -110,3 +112,35 @@ impl Config {
             .unwrap_or_else(|| "https://identity.bitwarden.com".to_string())
     }
 }
+
+#[cfg(unix)]
+pub fn inspect_config_permissions(config_path: &PathBuf) -> Result<Option<u32>> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let metadata = std::fs::metadata(config_path).with_context(|| {
+        format!(
+            "Failed to inspect permissions of config file: {}",
+            config_path.display()
+        )
+    })?;
+    let mode = metadata.permissions().mode() & 0o7777;
+
+    if mode != 0o600 {
+        log::warn!(
+            "Config file {} has permissions {:04o}; recommended permissions are 0600",
+            config_path.display(),
+            mode
+        );
+        return Ok(Some(mode));
+    }
+
+    Ok(None)
+}
+
+#[cfg(not(unix))]
+pub fn inspect_config_permissions(_config_path: &PathBuf) -> Result<Option<u32>> {
+    Ok(None)
+}
+
+#[cfg(all(test, unix))]
+mod tests;

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,9 +125,9 @@ pub fn inspect_config_permissions(config_path: &PathBuf) -> Result<Option<u32>> 
     })?;
     let mode = metadata.permissions().mode() & 0o7777;
 
-    if mode != 0o600 {
+    if mode & 0o1777 != mode & 0o600 {
         let msg = format!(
-            "Config file {} has permissions {:04o}; required permissions are 0600",
+            "Config file {} has permissions {:04o}; permissions must be no wider than 0600",
             config_path.display(),
             mode
         );

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,7 +125,7 @@ pub fn inspect_config_permissions(config_path: &PathBuf) -> Result<Option<u32>> 
     })?;
     let mode = metadata.permissions().mode() & 0o7777;
 
-    if mode & 0o1777 != mode & 0o600 {
+    if mode != mode & 0o600 {
         let msg = format!(
             "Config file {} has permissions {:04o}; permissions must be no wider than 0600",
             config_path.display(),

--- a/src/config/tests/common.rs
+++ b/src/config/tests/common.rs
@@ -1,0 +1,25 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn test_path(name: &str) -> PathBuf {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is before Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "vault-conductor-{name}-{}-{timestamp}.yaml",
+        std::process::id()
+    ))
+}
+
+pub fn create_config(path: &PathBuf, mode: u32) {
+    fs::write(
+        path,
+        "bws_access_token: token\nbw_secret_ids:\n  - secret-id\n",
+    )
+    .expect("failed to write test config");
+    fs::set_permissions(path, fs::Permissions::from_mode(mode))
+        .expect("failed to set test config permissions");
+}

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -1,0 +1,3 @@
+pub mod common;
+pub mod perms;
+pub mod validate;

--- a/src/config/tests/perms.rs
+++ b/src/config/tests/perms.rs
@@ -20,7 +20,7 @@ mod tests {
 
     #[test]
     fn permissions_wider_than_owner_only_are_rejected() {
-        for mode in [0o700, 0o640, 0o660, 0o601, 0o604] {
+        for mode in [0o700, 0o640, 0o660, 0o601, 0o604, 0o2600, 0o4600] {
             let path = test_path(&format!("{mode:o}"));
             create_config(&path, mode);
 

--- a/src/config/tests/perms.rs
+++ b/src/config/tests/perms.rs
@@ -6,24 +6,26 @@ mod tests {
     use std::fs;
 
     #[test]
-    fn exact_0600_permissions_are_accepted() {
-        let path = test_path("0600");
-        create_config(&path, 0o600);
+    fn owner_only_permissions_are_accepted() {
+        for mode in [0o400, 0o600] {
+            let path = test_path(&format!("{mode:o}"));
+            create_config(&path, mode);
 
-        assert_eq!(inspect_config_permissions(&path).unwrap(), None);
-        assert!(Config::load(&Some(path.to_string_lossy().into_owned())).is_ok());
+            assert_eq!(inspect_config_permissions(&path).unwrap(), None);
+            assert!(Config::load(&Some(path.to_string_lossy().into_owned())).is_ok());
 
-        fs::remove_file(path).expect("failed to remove test config");
+            fs::remove_file(path).expect("failed to remove test config");
+        }
     }
 
     #[test]
-    fn non_0600_permissions_are_rejected() {
-        for mode in [0o644, 0o660, 0o601] {
+    fn permissions_wider_than_owner_only_are_rejected() {
+        for mode in [0o700, 0o640, 0o660, 0o601, 0o604] {
             let path = test_path(&format!("{mode:o}"));
             create_config(&path, mode);
 
             let error = inspect_config_permissions(&path)
-                .expect_err("config permissions other than 0600 should fail");
+                .expect_err("config permissions wider than owner-only should fail");
             assert!(error.to_string().contains(&format!("{mode:04o}")));
             assert!(Config::load(&Some(path.to_string_lossy().into_owned())).is_err());
 

--- a/src/config/tests/perms.rs
+++ b/src/config/tests/perms.rs
@@ -1,0 +1,40 @@
+#[cfg(all(test, unix))]
+mod tests {
+    use crate::config::tests::common::{create_config, test_path};
+    use crate::config::{inspect_config_permissions, Config};
+
+    use std::fs;
+
+    #[test]
+    fn exact_0600_permissions_are_accepted() {
+        let path = test_path("0600");
+        create_config(&path, 0o600);
+
+        assert_eq!(inspect_config_permissions(&path).unwrap(), None);
+        assert!(Config::load(&Some(path.to_string_lossy().into_owned())).is_ok());
+
+        fs::remove_file(path).expect("failed to remove test config");
+    }
+
+    #[test]
+    fn non_0600_permissions_are_warned_about_and_accepted() {
+        for mode in [0o644, 0o660, 0o601] {
+            let path = test_path(&format!("{mode:o}"));
+            create_config(&path, mode);
+
+            assert_eq!(inspect_config_permissions(&path).unwrap(), Some(mode));
+            assert!(Config::load(&Some(path.to_string_lossy().into_owned())).is_ok());
+
+            fs::remove_file(path).expect("failed to remove test config");
+        }
+    }
+
+    #[test]
+    fn permission_inspection_failures_return_an_error() {
+        let path = test_path("missing");
+
+        let error = inspect_config_permissions(&path).expect_err("missing metadata should fail");
+
+        assert!(error.to_string().contains("Failed to inspect permissions"));
+    }
+}

--- a/src/config/tests/perms.rs
+++ b/src/config/tests/perms.rs
@@ -17,13 +17,15 @@ mod tests {
     }
 
     #[test]
-    fn non_0600_permissions_are_warned_about_and_accepted() {
+    fn non_0600_permissions_are_rejected() {
         for mode in [0o644, 0o660, 0o601] {
             let path = test_path(&format!("{mode:o}"));
             create_config(&path, mode);
 
-            assert_eq!(inspect_config_permissions(&path).unwrap(), Some(mode));
-            assert!(Config::load(&Some(path.to_string_lossy().into_owned())).is_ok());
+            let error = inspect_config_permissions(&path)
+                .expect_err("config permissions other than 0600 should fail");
+            assert!(error.to_string().contains(&format!("{mode:04o}")));
+            assert!(Config::load(&Some(path.to_string_lossy().into_owned())).is_err());
 
             fs::remove_file(path).expect("failed to remove test config");
         }

--- a/src/config/tests/validate.rs
+++ b/src/config/tests/validate.rs
@@ -11,7 +11,7 @@ mod tests {
     #[test]
     fn custom_config_path_is_validated() {
         let path = test_path("custom");
-        create_config(&path, 0o644);
+        create_config(&path, 0o600);
 
         assert!(Config::load(&Some(path.to_string_lossy().into_owned())).is_ok());
 

--- a/src/config/tests/validate.rs
+++ b/src/config/tests/validate.rs
@@ -8,6 +8,32 @@ mod tests {
 
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
+    struct EnvironmentGuard {
+        values: [(&'static str, Option<String>); 2],
+    }
+
+    impl EnvironmentGuard {
+        fn new() -> Self {
+            Self {
+                values: [
+                    ("BWS_ACCESS_TOKEN", std::env::var("BWS_ACCESS_TOKEN").ok()),
+                    ("BW_SECRET_IDS", std::env::var("BW_SECRET_IDS").ok()),
+                ],
+            }
+        }
+    }
+
+    impl Drop for EnvironmentGuard {
+        fn drop(&mut self) {
+            for (name, value) in &self.values {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+
     #[test]
     fn custom_config_path_is_validated() {
         let path = test_path("custom");
@@ -21,6 +47,7 @@ mod tests {
     #[test]
     fn missing_config_uses_environment_variables() {
         let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let _environment_guard = EnvironmentGuard::new();
         let path = test_path("environment");
         std::env::set_var("BWS_ACCESS_TOKEN", "environment-token");
         std::env::set_var("BW_SECRET_IDS", "environment-secret-id");
@@ -30,7 +57,5 @@ mod tests {
 
         assert_eq!(config.bws_access_token, "environment-token");
         assert_eq!(config.bw_secret_ids, vec!["environment-secret-id"]);
-        std::env::remove_var("BWS_ACCESS_TOKEN");
-        std::env::remove_var("BW_SECRET_IDS");
     }
 }

--- a/src/config/tests/validate.rs
+++ b/src/config/tests/validate.rs
@@ -1,0 +1,36 @@
+#[cfg(all(test, unix))]
+mod tests {
+    use crate::config::tests::common::{create_config, test_path};
+    use crate::config::Config;
+
+    use std::fs;
+    use std::sync::{Mutex, OnceLock};
+
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    #[test]
+    fn custom_config_path_is_validated() {
+        let path = test_path("custom");
+        create_config(&path, 0o644);
+
+        assert!(Config::load(&Some(path.to_string_lossy().into_owned())).is_ok());
+
+        fs::remove_file(path).expect("failed to remove test config");
+    }
+
+    #[test]
+    fn missing_config_uses_environment_variables() {
+        let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let path = test_path("environment");
+        std::env::set_var("BWS_ACCESS_TOKEN", "environment-token");
+        std::env::set_var("BW_SECRET_IDS", "environment-secret-id");
+
+        let config = Config::load(&Some(path.to_string_lossy().into_owned()))
+            .expect("environment-only configuration should load");
+
+        assert_eq!(config.bws_access_token, "environment-token");
+        assert_eq!(config.bw_secret_ids, vec!["environment-secret-id"]);
+        std::env::remove_var("BWS_ACCESS_TOKEN");
+        std::env::remove_var("BW_SECRET_IDS");
+    }
+}


### PR DESCRIPTION
This pull request introduces stricter validation for configuration file permissions to enhance security, ensuring that the config file is only accessible by its owner. It updates documentation to reflect these changes and adds comprehensive tests to verify correct behavior.

**Security improvements:**

* Added a new `inspect_config_permissions` function in `src/config.rs` to check that the config file permissions are no wider than `0600` (owner-only read/write); files with broader permissions are now rejected with an error.
* Updated the config file loading logic in `Config::load` to call `inspect_config_permissions` before reading the file.

**Documentation updates:**

* Changed the recommended permissions for the config file in `README.md` from `0660` to `0600` to match the new enforcement.
* Updated the config loading flowchart in `docs/CONFIG_LOAD.md` to show that owner-only permissions are required, and an error is raised otherwise.

**Testing improvements:**

* Added new test modules for permissions and validation in `src/config/tests/perms.rs` and `src/config/tests/validate.rs`, with supporting helpers in `src/config/tests/common.rs`, to ensure that only owner-only permissions are accepted and that permission errors are handled correctly. [[1]](diffhunk://#diff-5952a43138c5e8f7079552cc5046cc5aa42b2098cd82c3156f9d0474134ae20eR1-R44) [[2]](diffhunk://#diff-92fbc4196a01a2600303fc2bf7ca31e77aea43704fb35958b8e6d52683d63372R1-R36) [[3]](diffhunk://#diff-12ae84a5b7df2add3ca7c065a5adee3ce62206060e8855640dd807dbe4f761b5R1-R25) [[4]](diffhunk://#diff-0d4eae03301199cbc9b736b5d6f8b61654cc16ee1e04a0c58425daf0f97fdc90R1-R3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Configuration files are now required to use owner-only permissions (`0600`) on Unix systems.
  * Files accessible by groups or others are rejected with a clear error.
* **Documentation**
  * Updated installation guidance to recommend secure configuration-file permissions.
* **Tests**
  * Added coverage for accepted and rejected permissions, custom paths, and environment-based configuration loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->